### PR TITLE
fix #20 libsass issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "broccoli-sass": "0.6.4",
+    "broccoli-sass": "0.6.2",
     "ember-cli": "^0.2.0",
     "ember-cli-app-version": "0.3.2",
     "ember-cli-babel": "^4.3.0",


### PR DESCRIPTION
#20

```
expected a variable name (e.g. $x) or ')' for the parameter list for url
Error: expected a variable name (e.g. $x) or ')' for the parameter list for url
```

This issue is due to a bug in libsass.
see https://github.com/sass/libsass/issues/1059

After revert back to node-sass@3.0.0-beta.4, the issue is resolved but still build failed, hit another bug (https://github.com/sass/libsass/issues/1007).

```
Build failed.
File: /home/jacyzon/Project/paz/paz-web/bower_components/normalize-scss/_normalize.scss (433)
invalid top-level expression
Error: invalid top-level expression
    at Object.module.exports.renderSync (/home/jacyzon/Project/paz/paz-web/node_modules/broccoli-sass/node_modules/node-sass/lib/index.js:366:22)
    at SassCompiler.updateCache (/home/jacyzon/Project/paz/paz-web/node_modules/broccoli-sass/index.js:36:17)
    at /home/jacyzon/Project/paz/paz-web/node_modules/broccoli-sass/node_modules/broccoli-caching-writer/index.js:96:34
    at lib$rsvp$$internal$$tryCatch (/home/jacyzon/Project/paz/paz-web/node_modules/broccoli-sass/node_modules/broccoli-caching-writer/node_modules/rsvp/dist/rsvp.js:489:16)
    at lib$rsvp$$internal$$invokeCallback (/home/jacyzon/Project/paz/paz-web/node_modules/broccoli-sass/node_modules/broccoli-caching-writer/node_modules/rsvp/dist/rsvp.js:501:17)
    at lib$rsvp$$internal$$publish (/home/jacyzon/Project/paz/paz-web/node_modules/broccoli-sass/node_modules/broccoli-caching-writer/node_modules/rsvp/dist/rsvp.js:472:11)
    at lib$rsvp$asap$$flush (/home/jacyzon/Project/paz/paz-web/node_modules/broccoli-sass/node_modules/broccoli-caching-writer/node_modules/rsvp/dist/rsvp.js:1290:9)
    at process._tickCallback (node.js:355:11)
```

Now we revert back to node-sass@3.0.0-alpha.1 and everything works,
we can upgrade node-sass to 3.0 after stable release of node-sass.

```
jacyzon@CYPRESS ~/Project/paz/paz-web (fix-libsass-dependency)$ ember build                                                                                                                                                           [2.2.0]
The package `ember-data` is not a properly formatted package, we have used a fallback lookup to resolve it at `/home/jacyzon/Project/paz/paz-web/node_modules/ember-data`. This is generally caused by an addon not having a `main` entry point (or `index.js`).
version: 0.2.3
Could not find watchman, falling back to NodeWatcher for file system events.
Visit http://www.ember-cli.com/#watchman for more info.
BuildingThe package `ember-data` is not a properly formatted package, we have used a fallback lookup to resolve it at `/home/jacyzon/Project/paz/paz-web/node_modules/ember-data`. This is generally caused by an addon not having a `main` entry point (or `index.js`).
Building.
unit/adapters/load-balancer-test.js: line 11, col 3, 'ok' is not defined.

1 error

unit/components/quick-chart-test.js: line 9, col 3, 'expect' is not defined.
unit/components/quick-chart-test.js: line 13, col 3, 'equal' is not defined.
unit/components/quick-chart-test.js: line 17, col 3, 'equal' is not defined.

3 errors

unit/components/service-config-test.js: line 9, col 3, 'expect' is not defined.
unit/components/service-config-test.js: line 13, col 3, 'equal' is not defined.
unit/components/service-config-test.js: line 17, col 3, 'equal' is not defined.

3 errors

unit/controllers/application-test.js: line 11, col 3, 'ok' is not defined.

1 error

unit/controllers/host-test.js: line 11, col 3, 'ok' is not defined.

1 error

unit/controllers/services-test.js: line 11, col 3, 'ok' is not defined.

1 error

unit/controllers/unit-test.js: line 11, col 3, 'ok' is not defined.

1 error

unit/models/host-test.js: line 11, col 3, 'ok' is not defined.

1 error

unit/models/load-balancer-test.js: line 11, col 3, 'ok' is not defined.

1 error

unit/models/service-test.js: line 11, col 3, 'ok' is not defined.

1 error

unit/models/unit-test.js: line 11, col 3, 'ok' is not defined.

1 error

unit/routes/dashboard/index-test.js: line 10, col 3, 'ok' is not defined.

1 error

unit/routes/dashboard-test.js: line 10, col 3, 'ok' is not defined.

1 error

unit/routes/hosts-test.js: line 10, col 3, 'ok' is not defined.

1 error

unit/routes/index-test.js: line 10, col 3, 'ok' is not defined.

1 error

unit/routes/monitoring-test.js: line 10, col 3, 'ok' is not defined.

1 error

unit/routes/service/edit-test.js: line 10, col 3, 'ok' is not defined.

1 error

unit/routes/service-test.js: line 10, col 3, 'ok' is not defined.

1 error

unit/routes/services/new-test.js: line 10, col 3, 'ok' is not defined.

1 error

unit/routes/services-test.js: line 10, col 3, 'ok' is not defined.
unit/routes/services-test.js: line 12, col 3, 'equal' is not defined.

2 errors

unit/routes/styleguide-test.js: line 10, col 3, 'ok' is not defined.

1 error

unit/routes/units-test.js: line 10, col 3, 'ok' is not defined.

1 error

===== 22 JSHint Errors

Building...WARNING: The box-sizing mixin is deprecated and will be removed in the next major version release. This property can now be used un-prefixed.
    on line 410 of bower_components/bourbon/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss
    from line 50 of tmp/tree_merger-tmp_dest_dir-CuFqdpsE.tmp/app/styles/_form.scss

Built project successfully. Stored in "dist/".

```
