### PR TITLE
Do not use port 80 as a placeholder

### DIFF
--- a/app/templates/components/service-edit.hbs
+++ b/app/templates/components/service-edit.hbs
@@ -16,7 +16,7 @@
             {{input port.container placeholder=9000 label="container"}}
           </div>
           <div class="half">
-            {{input port.host placeholder=80 label="host"}}
+            {{input port.host placeholder=81 pattern="^(?!.*80).*$" oninvalid="setCustomValidity('You cannot use port 80')" label="host"}}
             <button class="btn btn--sad" style="float: right;" {{action 'removePort' config port}}>—</button>
           </div>
         </div>


### PR DESCRIPTION
Because HAProxy is already running on port 80 you cannot map your service's port to 80. If you do your service will die and no useful output will be in the journal.
